### PR TITLE
asynch 0.2.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/python-zstd-feedstock/pr1/39b6afe

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/python-zstd-feedstock/pr1/39b6afe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set name = "<PLEASE ADD PKG NAME>" %}
-{% set version = "<PLEASE ADD PKG VERSION>" %}
+{% set name = "asynch" %}
+{% set version = "0.2.4" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools
     - wheel
     - poetry-core
+    - zstd
   run:
     - python
     - leb128

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,9 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
+    - poetry-core
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,8 @@ requirements:
     - python-zstd
     - tzlocal
     - ciso8601
-    - clickhouse-cityhash
+    # not available on windows
+    - clickhouse-cityhash  # [unix]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: <sha256>
+  sha256: 15ef9517bb093dfd5a0f1f31cc31e0da84543eead0269345052922cf399d280e
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,6 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
     - poetry-core
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,6 @@ requirements:
     - python-zstd
     - tzlocal
     - ciso8601
-    # not available on windows
-    - clickhouse-cityhash  # [unix]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,19 +29,27 @@ test:
     - {{ name.replace('-', '.') }}
   requires:
     - pip
+    - leb128
+    - pytz
+    - lz4
+    - clickhouse-cityhash
+    - zstd
+    - tzlocal
+    - ciso8601
   commands:
     - pip check
 
 about:
-  home: <PLEASE ADD HOME URL>
-  summary: <PLEASE ADD SUMMARY>
+  home: https://github.com/long2ice/asynch
+  summary: An asyncio ClickHouse Python Driver with native (TCP) interface support.
   description: |
-    <PLEASE ADD DESCRIPTION>
-  license: <PLEASE ADD LICENSE>
-  license_family: <PLEASE ADD LICENSE_FAMILY>
-  license_file: <PLEASE_ADD_LICENSE_FILE>
-  dev_url: <PLEASE ADD DEV URL>
-  doc_url: <PLEASE ADD DOC URL>
+    asynch is an asynchronous ClickHouse Python driver with native TCP interface support,
+    which reuses most of clickhouse-driver features and complies with PEP249.
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  dev_url: https://github.com/long2ice/asynch
+  doc_url: https://github.com/long2ice/asynch
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,13 +21,12 @@ requirements:
     - setuptools
     - wheel
     - poetry-core
-    - zstd
   run:
     - python
     - leb128
     - pytz
     - lz4
-    - zstd
+    - python-zstd
     - tzlocal
     - ciso8601
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,19 +23,20 @@ requirements:
     - poetry-core
   run:
     - python
-
-test:
-  imports:
-    - {{ name.replace('-', '.') }}
-  requires:
-    - pip
     - leb128
     - pytz
     - lz4
-    - clickhouse-cityhash
     - zstd
     - tzlocal
     - ciso8601
+  run_constrained:
+    - clickhouse-cityhash
+
+test:
+  imports:
+    - asynch
+  requires:
+    - pip
   commands:
     - pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,12 +29,17 @@ requirements:
     - python-zstd
     - tzlocal
     - ciso8601
-  run_constrained:
     - clickhouse-cityhash
 
 test:
   imports:
     - asynch
+    - asynch.proto
+    - asynch.proto.columns
+    - asynch.proto.compression
+    - asynch.proto.settings
+    - asynch.proto.streams
+    - asynch.proto.utils
   requires:
     - pip
   commands:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4944](https://anaconda.atlassian.net/browse/PKG-4944)
- [Upstream repository](https://github.com/long2ice/asynch/tree/v0.2.4)
- [Upstream changelog/diff](https://github.com/long2ice/asynch/releases)
- Relevant dependency PRs:
  - asynch > clickhouse-sqlalchemy

### Explanation of changes:

- Initialize feedstock using grayskull
- Fill out recipe info
- Add necessary dependencies
- Linter fixes


[PKG-4944]: https://anaconda.atlassian.net/browse/PKG-4944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ